### PR TITLE
Expose custom tools and MCP endpoints to Temporal DeepAgent

### DIFF
--- a/discovery-agent/temporal/deep_agent.py
+++ b/discovery-agent/temporal/deep_agent.py
@@ -12,6 +12,22 @@ and optional metadata.  The ``router`` tool selects a subagent based on a
 natural-language description.  ``call_subagent`` accepts either an explicit
 subagent name or a description and dispatches to :func:`run_agent` with the
 corresponding instructions.
+
+Custom LangChain tools or external MCP servers can augment the agent.  Any
+tools discovered from MCP endpoints are merged with the built-ins before the
+model is bound::
+
+    from langchain_core.tools import tool
+
+    @tool
+    def add(x: int, y: int) -> int:
+        return x + y
+
+    await run_agent(
+        "2 + 2?",
+        tools=[add],
+        mcp_endpoints=["http://localhost:8000/mcp"],
+    )
 """
 
 from __future__ import annotations
@@ -25,6 +41,8 @@ from langchain_core.messages import (
     ToolMessage,
 )
 from langchain_core.tools import BaseTool, tool
+from mcp.client.session import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
 
 from openai_model import get_default_model
 
@@ -77,6 +95,7 @@ async def run_agent(
     question: str,
     instructions: str = "",
     tools: Sequence[BaseTool] | None = None,
+    mcp_endpoints: Sequence[str] | None = None,
     *,
     allow_tools: Iterable[str] | None = None,
     on_tool_call: Callable[[str, Dict[str, Any]], tuple[bool, Dict[str, Any]]] | None = None,
@@ -85,14 +104,40 @@ async def run_agent(
 ) -> str:
     """Execute the DeepAgent loop and return the final response text.
 
-    Tool execution can be restricted via ``allow_tools`` and inspected or
-    modified with the ``on_tool_call`` callback.
+    Additional LangChain ``tools`` or MCP server URLs can be supplied to extend
+    the agent's capabilities.  Any tools discovered from ``mcp_endpoints`` are
+    merged with the built-ins before the model is bound.  Tool execution can be
+    restricted via ``allow_tools`` and inspected or modified with the
+    ``on_tool_call`` callback.
     """
 
     state = _state or {"files": {}, "todos": []}
     files: Dict[str, str] = state["files"]
     todos: List[str] = state["todos"]
-    extra_tools = list(tools or [])
+    extra_tools: List[BaseTool] = list(tools or [])
+    if mcp_endpoints:
+        for endpoint in mcp_endpoints:
+            async with streamablehttp_client(endpoint) as (read, write, _):
+                async with ClientSession(read, write) as session:
+                    await session.initialize()
+                    listing = await session.list_tools()
+            for remote in listing.tools:
+                @tool(name=remote.name, description=remote.description or "")
+                async def _mcp_tool(
+                    _endpoint: str = endpoint,
+                    _name: str = remote.name,
+                    **kwargs: Any,
+                ) -> str:
+                    async with streamablehttp_client(_endpoint) as (r, w, _):
+                        async with ClientSession(r, w) as session:
+                            await session.initialize()
+                            result = await session.call_tool(_name, kwargs)
+                    parts = [
+                        item.text for item in result.content if hasattr(item, "text")
+                    ]
+                    return "\n".join(parts)
+
+                extra_tools.append(_mcp_tool)
     allowed_tool_set = set(allow_tools) if allow_tools is not None else None
 
     @tool

--- a/discovery-agent/temporal/temporal_workflow.py
+++ b/discovery-agent/temporal/temporal_workflow.py
@@ -4,21 +4,53 @@ The workflow delegates execution to an activity that instantiates and runs
 our minimal DeepAgent powered by OpenAI's tool calling.  This provides the
 same capabilities as the original LangGraph version while leveraging
 Temporal's reliability semantics.
+
+Custom tools or connections to external [MCP](https://github.com/modelcontextprotocol)
+servers can be supplied when starting the workflow.  Any tools returned from the
+MCP endpoints are merged with the agent's built-ins::
+
+    from langchain_core.tools import tool
+
+    @tool
+    def hello() -> str:
+        return "hi"
+
+    await client.execute_workflow(
+        DeepAgentWorkflow.run,
+        "Say hello",
+        tools=[hello],
+        mcp_endpoints=["http://localhost:8000/mcp"],
+        id="demo-run",
+        task_queue="deep-agent-task-queue",
+    )
 """
 
 from __future__ import annotations
 
 from datetime import timedelta
+from typing import Sequence
+
 from temporalio import activity, workflow
+from langchain_core.tools import BaseTool
 
 from deep_agent import run_agent
 
 
 @activity.defn
-async def run_query(question: str, instructions: str = "") -> str:
+async def run_query(
+    question: str,
+    instructions: str = "",
+    tools: Sequence[BaseTool] | None = None,
+    mcp_endpoints: Sequence[str] | None = None,
+) -> str:
     """Execute the DeepAgent for the supplied question."""
 
-    return await run_agent(question, instructions)
+    return await run_agent(
+        question,
+        instructions,
+        tools=tools,
+        mcp_endpoints=mcp_endpoints,
+    )
 
 
 @workflow.defn
@@ -26,10 +58,18 @@ class DeepAgentWorkflow:
     """Workflow that runs the DeepAgent loop as an activity."""
 
     @workflow.run
-    async def run(self, question: str, instructions: str = "") -> str:  # pragma: no cover - workflow entrypoint
+    async def run(
+        self,
+        question: str,
+        instructions: str = "",
+        tools: Sequence[BaseTool] | None = None,
+        mcp_endpoints: Sequence[str] | None = None,
+    ) -> str:  # pragma: no cover - workflow entrypoint
         return await workflow.execute_activity(
             run_query,
             question,
             instructions,
+            tools,
+            mcp_endpoints,
             schedule_to_close_timeout=timedelta(minutes=1),
         )


### PR DESCRIPTION
## Summary
- allow workflow activities to accept custom tools and MCP endpoint URLs
- load tools from MCP servers and merge with built-ins before model binding
- document how to pass tools or MCP connections into the workflow

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afeac8e69c832aac87f8aaa6cd8d61