### PR TITLE
feat: expand agent state

### DIFF
--- a/discovery-agent/temporal/deep_agent.py
+++ b/discovery-agent/temporal/deep_agent.py
@@ -31,7 +31,7 @@ defaults.
 
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, Iterable, List, Sequence
+from typing import Any, Callable, Dict, Iterable, List, Sequence, TypedDict
 
 from langchain_core.messages import (
     AIMessage,
@@ -44,6 +44,21 @@ from mcp.client.session import ClientSession
 from mcp.client.streamable_http import streamablehttp_client
 
 from openai_model import get_default_model
+
+
+class AgentState(TypedDict, total=False):
+    """State container shared across agent invocations.
+
+    Mirrors LangGraph's ``AgentState`` by persisting the conversation ``messages``,
+    the remaining step budget, the evolving in-memory ``files``/``todos`` and the
+    final ``response``.
+    """
+
+    files: Dict[str, str]
+    todos: List[str]
+    messages: List[Any]
+    remaining_steps: int
+    response: Dict[str, Any] | None
 
 # -------------------------------
 # Subagent registry
@@ -112,9 +127,25 @@ async def run_agent(
     ``on_tool_call`` callback.
     """
 
-    state = _state or {"files": {}, "todos": []}
+    state: AgentState = (
+        _state
+        if _state is not None
+        else {
+            "files": {},
+            "todos": [],
+            "messages": [],
+            "remaining_steps": _steps,
+            "response": None,
+        }
+    )
+    state.setdefault("files", {})
+    state.setdefault("todos", [])
+    state.setdefault("messages", [])
+    state.setdefault("remaining_steps", _steps)
+    state.setdefault("response", None)
     files: Dict[str, str] = state["files"]
     todos: List[str] = state["todos"]
+    messages: List[Any] = state["messages"]
     extra_tools: List[BaseTool] = list(tools or [])
     if mcp_endpoints:
         for endpoint in mcp_endpoints:
@@ -190,7 +221,7 @@ async def run_agent(
             allow_tools=allow_tools,
             on_tool_call=on_tool_call,
             _state=state,
-            _steps=_steps,
+            _steps=state.get("remaining_steps", _steps),
             base_prompt=base_prompt,
             model=model,
             subagents=subagents,
@@ -211,12 +242,16 @@ async def run_agent(
     bound_model = (model or get_default_model()).bind_tools(all_tools)
 
     system = base_prompt + ("\n\n" + instructions if instructions else "")
-    messages: List[Any] = [SystemMessage(content=system), HumanMessage(content=question)]
+    if not messages:
+        messages.append(SystemMessage(content=system))
+    messages.append(HumanMessage(content=question))
 
-    for _ in range(_steps):
+    while state["remaining_steps"] > 0:
+        state["remaining_steps"] -= 1
         ai: AIMessage = await bound_model.ainvoke(messages)
         messages.append(ai)
         if not ai.tool_calls:
+            state["response"] = {"content": ai.content or ""}
             return ai.content or ""
         for call in ai.tool_calls:
             name = call["name"]

--- a/discovery-agent/temporal/deep_agent.py
+++ b/discovery-agent/temporal/deep_agent.py
@@ -213,7 +213,7 @@ async def run_agent(
         name = subagent or _select_subagent(description or question, subagents)
         config = subagents.get(name, {})
         instr = config if isinstance(config, str) else config.get("instructions", "")
-        return await run_agent(
+        result = await run_agent(
             question,
             instr,
             tools=tools,
@@ -226,6 +226,9 @@ async def run_agent(
             model=model,
             subagents=subagents,
         )
+        parent_system = base_prompt + ("\n\n" + instructions if instructions else "")
+        messages.append(SystemMessage(content=parent_system))
+        return result
 
     builtin_tools: List[BaseTool] = [
         write_todos,
@@ -242,8 +245,7 @@ async def run_agent(
     bound_model = (model or get_default_model()).bind_tools(all_tools)
 
     system = base_prompt + ("\n\n" + instructions if instructions else "")
-    if not messages:
-        messages.append(SystemMessage(content=system))
+    messages.append(SystemMessage(content=system))
     messages.append(HumanMessage(content=question))
 
     while state["remaining_steps"] > 0:

--- a/discovery-agent/temporal/test_deep_agent.py
+++ b/discovery-agent/temporal/test_deep_agent.py
@@ -1,7 +1,7 @@
 import sys
 import types
 import pytest
-from langchain_core.messages import AIMessage
+from langchain_core.messages import AIMessage, SystemMessage
 from pathlib import Path
 
 
@@ -196,4 +196,49 @@ async def test_run_agent_tracks_state():
     assert isinstance(state["messages"][2], AIMessage)
     assert state["remaining_steps"] == 2
     assert state["response"] == {"content": "done"}
+
+
+class InstructionTrackingModel:
+    """Model that records messages across calls and triggers a subagent."""
+
+    def __init__(self) -> None:
+        self.calls = []
+        self.step = 0
+
+    def bind_tools(self, tools):
+        self.tools = tools
+        return self
+
+    async def ainvoke(self, messages):
+        self.calls.append(list(messages))
+        self.step += 1
+        if self.step == 1:
+            return AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "id": "1",
+                        "name": "call_subagent",
+                        "args": {"question": "inner", "subagent": "code"},
+                    }
+                ],
+            )
+        elif self.step == 2:
+            return AIMessage(content="inner done")
+        return AIMessage(content="outer done")
+
+
+@pytest.mark.asyncio
+async def test_subagent_instructions_preserved():
+    model = InstructionTrackingModel()
+    result = await run_agent(
+        "outer task", instructions="parent", model=model, _state={}, _steps=5
+    )
+    assert result == "outer done"
+    sub_call_msgs = model.calls[1]
+    assert isinstance(sub_call_msgs[-2], SystemMessage)
+    assert "coding specialist" in sub_call_msgs[-2].content
+    outer_call_msgs = model.calls[2]
+    assert isinstance(outer_call_msgs[-2], SystemMessage)
+    assert "parent" in outer_call_msgs[-2].content
 

--- a/discovery-agent/temporal/test_deep_agent.py
+++ b/discovery-agent/temporal/test_deep_agent.py
@@ -69,7 +69,7 @@ temporal_stub.workflow = types.SimpleNamespace(defn=lambda f: f, run=lambda f: f
 sys.modules["temporalio"] = temporal_stub
 
 sys.path.append(str(Path(__file__).resolve().parent.parent))
-from deep_agent import create_deep_agent
+from deep_agent import create_deep_agent, run_agent
 import temporal_workflow
 
 
@@ -172,4 +172,28 @@ async def test_call_subagent_forwards_factory_config(monkeypatch):
     assert inner_kwargs.get("base_prompt") == "PROMPT"
     assert inner_kwargs.get("model") is model
     assert inner_kwargs.get("subagents") == sub_cfg
+
+
+class EchoModel:
+    """Model that returns a fixed response."""
+
+    def bind_tools(self, tools):
+        return self
+
+    async def ainvoke(self, messages):
+        return AIMessage(content="done")
+
+
+@pytest.mark.asyncio
+async def test_run_agent_tracks_state():
+    state = {}
+    result = await run_agent("hi", model=EchoModel(), _state=state, _steps=3)
+    assert result == "done"
+    from langchain_core.messages import SystemMessage, HumanMessage, AIMessage
+
+    assert isinstance(state["messages"][0], SystemMessage)
+    assert isinstance(state["messages"][1], HumanMessage)
+    assert isinstance(state["messages"][2], AIMessage)
+    assert state["remaining_steps"] == 2
+    assert state["response"] == {"content": "done"}
 


### PR DESCRIPTION
## Summary
- track messages, remaining steps and final response in AgentState
- share remaining step budget with delegated subagents
- test that agent state captures conversation history

## Testing
- `pytest discovery-agent/temporal/test_deep_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_68aff3187334832aadc7723907061b42