### PR TITLE
feat: add subagent router and documentation

### DIFF
--- a/discovery-agent/temporal/deep_agent.py
+++ b/discovery-agent/temporal/deep_agent.py
@@ -8,10 +8,24 @@ decide when to invoke tools and stops when the model returns a final message
 with no tool calls.
 
 Subagents are configured via a registry mapping names to instruction strings
-and optional metadata.  The ``router`` tool selects a subagent based on a
-natural-language description.  ``call_subagent`` accepts either an explicit
-subagent name or a description and dispatches to :func:`run_agent` with the
-corresponding instructions.
+and optional metadata::
+
+    SUBAGENTS = {
+        "code": {
+            "instructions": "You are a coding specialist…",
+            "keywords": ["code", "bug"],
+        },
+        "docs": {
+            "instructions": "You write and update documentation…",
+            "keywords": ["doc", "write"],
+        },
+    }
+
+The :func:`router` tool chooses a subagent given a natural-language
+description by matching these keyword lists.  ``call_subagent`` accepts either
+an explicit subagent name or falls back to the ``router`` when ``subagent`` is
+``None``, dispatching to :func:`run_agent` with the selected subagent's
+instructions.
 
 External MCP servers or direct :class:`~langchain_core.tools.BaseTool` instances
 can augment the agent.  Any provided tools are merged with the built-ins before
@@ -210,7 +224,11 @@ async def run_agent(
         question: str, subagent: str | None = None, description: str = ""
     ) -> str:
         """Delegate ``question`` to a specialized subagent."""
-        name = subagent or _select_subagent(description or question, subagents)
+        name = (
+            subagent
+            if subagent and subagent in subagents
+            else _select_subagent(description or question, subagents)
+        )
         config = subagents.get(name, {})
         instr = config if isinstance(config, str) else config.get("instructions", "")
         result = await run_agent(

--- a/discovery-agent/temporal/test_deep_agent.py
+++ b/discovery-agent/temporal/test_deep_agent.py
@@ -174,6 +174,57 @@ async def test_call_subagent_forwards_factory_config(monkeypatch):
     assert inner_kwargs.get("subagents") == sub_cfg
 
 
+class RouterModel:
+    """Model that omits the subagent name and relies on the router."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def bind_tools(self, tools):
+        self.tools = tools
+        return self
+
+    async def ainvoke(self, messages):
+        self.calls += 1
+        if self.calls == 1:
+            return AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "id": "1",
+                        "name": "call_subagent",
+                        "args": {"question": "sub", "description": "write docs"},
+                    }
+                ],
+            )
+        elif self.calls == 2:
+            return AIMessage(content="inner done")
+        return AIMessage(content="outer done")
+
+
+@pytest.mark.asyncio
+async def test_call_subagent_uses_router(monkeypatch):
+    import deep_agent
+
+    calls = []
+    orig = deep_agent.run_agent
+
+    async def recording_run_agent(*args, **kwargs):
+        calls.append((args, kwargs))
+        return await orig(*args, **kwargs)
+
+    monkeypatch.setattr(deep_agent, "run_agent", recording_run_agent)
+
+    model = RouterModel()
+    agent = deep_agent.create_deep_agent(model=model)
+    result = await agent("task")
+    assert result == "outer done"
+    assert len(calls) == 2
+    inner_args, _ = calls[1]
+    expected = deep_agent.SUBAGENTS["docs"]["instructions"]
+    assert inner_args[1] == expected
+
+
 class EchoModel:
     """Model that returns a fixed response."""
 


### PR DESCRIPTION
## Summary
- document subagent registry and routing in DeepAgent
- fall back to router when call_subagent has no valid name
- exercise router via new tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68affaa26300832ab4300f619f34cf16