### PR TITLE
Add tests for DeepAgent tool gating hooks

### DIFF
--- a/discovery-agent/temporal/deep_agent.py
+++ b/discovery-agent/temporal/deep_agent.py
@@ -136,9 +136,16 @@ async def run_agent(
     """Execute the DeepAgent loop and return the final response text.
 
     Additional tools from ``tools`` and ``mcp_endpoints`` are merged with the
-    agent's built-ins before the model is bound.  Tool execution can be
-    restricted via ``allow_tools`` and inspected or modified with the
-    ``on_tool_call`` callback.
+    agent's built-ins before the model is bound.
+
+    Args:
+        allow_tools: Optional iterable of tool names that may be executed. If
+            provided, any tool not in this allowlist will be skipped and a
+            ``ToolMessage`` noting the block will be appended to the state.
+        on_tool_call: Optional callback invoked before each tool execution. It
+            receives the tool name and argument dictionary and returns a tuple
+            ``(allowed, new_args)``. When ``allowed`` is ``False`` the tool call
+            is denied and a corresponding ``ToolMessage`` is recorded.
     """
 
     state: AgentState = (
@@ -321,7 +328,9 @@ def create_deep_agent(
 
     Parameters mirror those of :func:`run_agent` but are applied up-front so
     callers need only provide the question (and optional instructions) each
-    time the returned callable is invoked.
+    time the returned callable is invoked.  The resulting callable still
+    accepts ``allow_tools`` and ``on_tool_call`` to control tool execution at
+    runtime.
     """
 
     subagent_cfg = subagents or SUBAGENTS

--- a/discovery-agent/temporal/test_deep_agent.py
+++ b/discovery-agent/temporal/test_deep_agent.py
@@ -1,7 +1,7 @@
 import sys
 import types
 import pytest
-from langchain_core.messages import AIMessage, SystemMessage
+from langchain_core.messages import AIMessage, SystemMessage, ToolMessage
 from pathlib import Path
 
 
@@ -292,4 +292,76 @@ async def test_subagent_instructions_preserved():
     outer_call_msgs = model.calls[2]
     assert isinstance(outer_call_msgs[-2], SystemMessage)
     assert "parent" in outer_call_msgs[-2].content
+
+
+class BlockToolModel:
+    """Model that attempts to invoke a disallowed tool."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def bind_tools(self, tools):
+        self.tools = tools
+        return self
+
+    async def ainvoke(self, messages):
+        self.calls += 1
+        if self.calls == 1:
+            return AIMessage(
+                content="",
+                tool_calls=[{"id": "1", "name": "ls", "args": {}}],
+            )
+        return AIMessage(content="done")
+
+
+@pytest.mark.asyncio
+async def test_allow_tools_blocks_unlisted_tool():
+    state = {}
+    result = await run_agent(
+        "task", model=BlockToolModel(), allow_tools=["read_file"], _state=state, _steps=3
+    )
+    assert result == "done"
+    tool_msgs = [m for m in state["messages"] if isinstance(m, ToolMessage)]
+    assert any("blocked" in m.content for m in tool_msgs)
+
+
+class ModifyArgsModel:
+    """Model that writes a file whose content is tweaked by a callback."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def bind_tools(self, tools):
+        return self
+
+    async def ainvoke(self, messages):
+        self.calls += 1
+        if self.calls == 1:
+            return AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "id": "1",
+                        "name": "write_file",
+                        "args": {"path": "a.txt", "content": "orig"},
+                    }
+                ],
+            )
+        return AIMessage(content="done")
+
+
+@pytest.mark.asyncio
+async def test_on_tool_call_can_modify_args():
+    state = {}
+
+    def approve(name, args):
+        assert name == "write_file"
+        args["content"] = "changed"
+        return True, args
+
+    result = await run_agent(
+        "task", model=ModifyArgsModel(), on_tool_call=approve, _state=state, _steps=3
+    )
+    assert result == "done"
+    assert state["files"]["a.txt"] == "changed"
 


### PR DESCRIPTION
## Summary
- document allowlist and tool-call callback parameters
- test blocking tools via `allow_tools`
- test modifying tool arguments via `on_tool_call`

## Testing
- `pip install pytest-asyncio`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68affd6b06a0832abd4ea4260ecf39db