### PR TITLE
Add DeepAgent factory and update Temporal workflow

### DIFF
--- a/discovery-agent/README.md
+++ b/discovery-agent/README.md
@@ -1,0 +1,18 @@
+# Discovery Agent
+
+The `temporal.deep_agent` module provides a minimal autonomous agent used by the
+Temporal workflow examples.  The new `create_deep_agent` factory makes it easy
+to build a pre-configured agent with a base prompt, model, subagent registry,
+extra tools, and step limit.
+
+```python
+from temporal.deep_agent import create_deep_agent
+from langchain_community.tools import RequestsGetTool
+
+agent = create_deep_agent(tools=[RequestsGetTool()])
+result = await agent("2 + 2?")
+```
+
+The returned callable mirrors `run_agent` but applies the configuration above on
+every invocation, letting callers focus on the question and optional
+instructions.

--- a/discovery-agent/temporal/deep_agent.py
+++ b/discovery-agent/temporal/deep_agent.py
@@ -1,4 +1,4 @@
-"""Minimal DeepAgent implementation used by Temporal workflows.
+"""Minimal DeepAgent implementation and factory used by Temporal workflows.
 
 This module provides a very small yet capable autonomous agent that mirrors the
 behaviour of the LangGraph DeepAgent.  It maintains an in-memory filesystem and

--- a/discovery-agent/temporal/temporal_workflow.py
+++ b/discovery-agent/temporal/temporal_workflow.py
@@ -1,9 +1,9 @@
 """Temporal workflow that runs the custom DeepAgent implementation.
 
-The workflow delegates execution to an activity that instantiates and runs
-our minimal DeepAgent powered by OpenAI's tool calling.  This provides the
-same capabilities as the original LangGraph version while leveraging
-Temporal's reliability semantics.
+The workflow delegates execution to an activity that constructs a DeepAgent
+via :func:`~deep_agent.create_deep_agent` and runs it using OpenAI's tool
+calling.  This provides the same capabilities as the original LangGraph
+version while leveraging Temporal's reliability semantics.
 
 Connections to external [MCP](https://github.com/modelcontextprotocol)
 servers or additional LangChain tools can be supplied when starting the
@@ -30,7 +30,7 @@ from typing import Sequence
 from langchain_core.tools import BaseTool
 from temporalio import activity, workflow
 
-from deep_agent import run_agent
+from deep_agent import create_deep_agent
 
 
 def _load_tool(spec: str) -> BaseTool:
@@ -55,12 +55,8 @@ async def run_query(
 ) -> str:
     """Execute the DeepAgent for the supplied question."""
     tool_objs = [_load_tool(t) for t in tools] if tools else None
-    return await run_agent(
-        question,
-        instructions,
-        tools=tool_objs,
-        mcp_endpoints=mcp_endpoints,
-    )
+    agent = create_deep_agent(tools=tool_objs, mcp_endpoints=mcp_endpoints)
+    return await agent(question, instructions)
 
 
 @workflow.defn

--- a/discovery-agent/temporal/test_deep_agent.py
+++ b/discovery-agent/temporal/test_deep_agent.py
@@ -104,28 +104,30 @@ async def test_create_deep_agent_applies_base_prompt():
 @pytest.mark.asyncio
 async def test_run_query_forwards_tools_and_endpoints(monkeypatch):
     called: dict[str, Any] = {}
-
-    async def stub_run_agent(question, instructions="", **kwargs):
-        called["args"] = (question, instructions)
-        called["kwargs"] = kwargs
-        return "ok"
-
     dummy_tool = object()
 
     def stub_load_tool(spec: str):
         called.setdefault("loaded", []).append(spec)
         return dummy_tool
 
-    monkeypatch.setattr(temporal_workflow, "run_agent", stub_run_agent)
+    async def stub_agent(question, instructions="", **kwargs):
+        called["agent_args"] = (question, instructions)
+        return "ok"
+
+    def stub_factory(**kwargs):
+        called["factory_kwargs"] = kwargs
+        return stub_agent
+
     monkeypatch.setattr(temporal_workflow, "_load_tool", stub_load_tool)
+    monkeypatch.setattr(temporal_workflow, "create_deep_agent", stub_factory)
 
     result = await temporal_workflow.run_query(
         "Q", "I", tools=["pkg:tool"], mcp_endpoints=["http://server"]
     )
     assert result == "ok"
-    assert called["args"] == ("Q", "I")
-    assert called["kwargs"]["tools"] == [dummy_tool]
-    assert called["kwargs"]["mcp_endpoints"] == ["http://server"]
+    assert called["agent_args"] == ("Q", "I")
+    assert called["factory_kwargs"]["tools"] == [dummy_tool]
+    assert called["factory_kwargs"]["mcp_endpoints"] == ["http://server"]
     assert called["loaded"] == ["pkg:tool"]
 
 


### PR DESCRIPTION
## Summary
- add `create_deep_agent` factory for pre-configured DeepAgent instances
- update Temporal run_query to use the factory
- document factory usage in module docstring and README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0048a60cc832aa0af1fa541d67348