### PR TITLE
Add registries for tools and agent goals

### DIFF
--- a/discovery-agent/temporal/goal_registry.py
+++ b/discovery-agent/temporal/goal_registry.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+"""Registry of predefined :class:`AgentGoal` objects and their starter prompts."""
+
+from typing import Dict
+
+from registries import AgentGoal
+
+GOAL_REGISTRY: Dict[AgentGoal, str] = {
+    AgentGoal(
+        name="write_docs",
+        description="Produce or update project documentation",
+    ): "You are a technical writer tasked with creating clear project documentation.",
+    AgentGoal(
+        name="fix_bug",
+        description="Investigate and resolve issues in the codebase",
+    ): "You are a debugging assistant focused on identifying and fixing code bugs.",
+}

--- a/discovery-agent/temporal/registries.py
+++ b/discovery-agent/temporal/registries.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+"""Lightweight dataclasses for registry definitions.
+
+These structures describe tools and agent goals in a serialisable format so
+that registries can reference them as keys.  The dataclasses are frozen to
+allow instances to be used as dictionary keys.
+"""
+
+from dataclasses import dataclass, asdict
+from typing import Tuple
+
+
+@dataclass(frozen=True)
+class ToolArgument:
+    """Description of a single tool argument."""
+
+    name: str
+    type: str
+    description: str
+    required: bool = True
+
+    def to_dict(self) -> dict:
+        """Return a serialisable representation of the argument."""
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ToolDefinition:
+    """Definition for a callable tool."""
+
+    name: str
+    description: str
+    arguments: Tuple[ToolArgument, ...] = ()
+
+    def to_dict(self) -> dict:
+        """Return a serialisable representation of the tool."""
+        return {
+            "name": self.name,
+            "description": self.description,
+            "arguments": [arg.to_dict() for arg in self.arguments],
+        }
+
+
+@dataclass(frozen=True)
+class AgentGoal:
+    """Represents a high level goal available to the agent."""
+
+    name: str
+    description: str
+
+    def to_dict(self) -> dict:
+        """Return a serialisable representation of the goal."""
+        return asdict(self)

--- a/discovery-agent/temporal/tool_registry.py
+++ b/discovery-agent/temporal/tool_registry.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+"""Registry mapping ``ToolDefinition`` objects to their handlers."""
+
+from typing import Callable, Dict
+
+from registries import ToolArgument, ToolDefinition
+
+
+def add(a: int, b: int) -> int:
+    """Return the sum of two integers."""
+    return a + b
+
+
+def echo(text: str) -> str:
+    """Return the provided text verbatim."""
+    return text
+
+
+TOOL_REGISTRY: Dict[ToolDefinition, Callable] = {
+    ToolDefinition(
+        name="add",
+        description="Add two integers",
+        arguments=(
+            ToolArgument("a", "int", "First integer"),
+            ToolArgument("b", "int", "Second integer"),
+        ),
+    ): add,
+    ToolDefinition(
+        name="echo",
+        description="Echo back the supplied text",
+        arguments=(ToolArgument("text", "str", "Text to echo"),),
+    ): echo,
+}

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -1,0 +1,55 @@
+import sys
+from pathlib import Path
+from dataclasses import asdict
+
+# Make registry modules importable
+sys.path.append(str(Path(__file__).resolve().parents[1] / "discovery-agent/temporal"))
+
+import registries
+import tool_registry
+import goal_registry
+
+
+def _get_tool_def(name: str):
+    for td in tool_registry.TOOL_REGISTRY:
+        if td.name == name:
+            return td
+    raise KeyError(name)
+
+
+def _get_goal(name: str):
+    for goal in goal_registry.GOAL_REGISTRY:
+        if goal.name == name:
+            return goal
+    raise KeyError(name)
+
+
+def test_tool_registry_lookup_and_serialisation():
+    add_def = _get_tool_def("add")
+    handler = tool_registry.TOOL_REGISTRY[add_def]
+    assert handler(2, 3) == 5
+
+    data = asdict(add_def)
+    assert data["name"] == "add"
+    assert data["arguments"][0]["name"] == "a"
+    assert data["arguments"][1]["name"] == "b"
+
+    arg_data = asdict(add_def.arguments[0])
+    assert arg_data == {
+        "name": "a",
+        "type": "int",
+        "description": "First integer",
+        "required": True,
+    }
+
+
+def test_goal_registry_lookup_and_serialisation():
+    goal = _get_goal("write_docs")
+    prompt = goal_registry.GOAL_REGISTRY[goal]
+    assert "documentation" in prompt.lower()
+
+    data = asdict(goal)
+    assert data == {
+        "name": "write_docs",
+        "description": "Produce or update project documentation",
+    }


### PR DESCRIPTION
## Summary
- Define serialisable dataclasses for tool arguments, tools and agent goals
- Introduce tool and goal registries with example entries
- Add unit tests validating registry lookup and dataclass serialisation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b06a5f3210832ab7afa7dac04f0d26