### PR TITLE
Add Temporal agent activities with tool dispatch and tests

### DIFF
--- a/discovery-agent/temporal/agent_activities.py
+++ b/discovery-agent/temporal/agent_activities.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+"""Temporal activities used by the Discovery agent workflow.
+
+This module exposes a small set of activities that help orchestrate the
+agent's behaviour within a Temporal workflow.  Activities cover prompt
+validation, planning tool calls and retrieving environment variables for the
+workflow run.
+"""
+
+from dataclasses import dataclass
+import json
+import os
+from typing import Any, Dict
+
+from temporalio import activity
+
+from tool_registry import TOOL_REGISTRY
+
+
+@dataclass
+class AgentActivities:
+    """Collection of Temporal activities for the agent workflow."""
+
+    def _sanitize_json(self, text: str) -> str:
+        """Strip code fences and surrounding whitespace from ``text``.
+
+        The agent may produce JSON wrapped in markdown code fences or preceded
+        by a ``json`` language tag.  This helper removes those decorations so
+        the remaining string can be parsed as valid JSON.
+        """
+
+        cleaned = text.strip()
+        if cleaned.startswith("```") and cleaned.endswith("```"):
+            cleaned = cleaned.strip("`\n")
+            if "\n" in cleaned:
+                first, rest = cleaned.split("\n", 1)
+                if first.strip().lower() == "json":
+                    cleaned = rest
+                else:
+                    cleaned = first + rest
+        return cleaned
+
+    def _parse_json(self, text: str) -> Dict[str, Any]:
+        """Parse ``text`` into a JSON object after sanitisation."""
+
+        try:
+            return json.loads(self._sanitize_json(text))
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+            raise ValueError("Invalid JSON") from exc
+
+    def _dispatch_tool(self, name: str, args: Dict[str, Any]) -> Any:
+        """Execute a tool from ``TOOL_REGISTRY``.
+
+        Args:
+            name: Name of the tool to execute.
+            args: Arguments to pass to the tool handler.
+        """
+
+        for definition, handler in TOOL_REGISTRY.items():
+            if definition.name == name:
+                return handler(**args)
+        raise KeyError(f"Unknown tool: {name}")
+
+    @activity.defn
+    async def agent_toolPlanner(self, prompt: str) -> Any:
+        """Plan and execute a tool call based on ``prompt``.
+
+        ``prompt`` should contain JSON with ``tool`` and optional ``args``
+        fields.  The named tool is executed and its return value provided
+        verbatim.
+        """
+
+        data = self._parse_json(prompt)
+        tool_name = data.get("tool")
+        if not tool_name:
+            raise ValueError("Missing 'tool' field")
+        args = data.get("args", {})
+        if not isinstance(args, dict):
+            raise ValueError("'args' must be an object")
+        return self._dispatch_tool(tool_name, args)
+
+    @activity.defn
+    async def agent_validatePrompt(self, prompt: str) -> Dict[str, Any]:
+        """Validate ``prompt`` and return the parsed structure.
+
+        Validation ensures that the required ``tool`` key exists and that
+        ``args`` is a JSON object if supplied.
+        """
+
+        data = self._parse_json(prompt)
+        if "tool" not in data:
+            raise ValueError("Missing 'tool' field")
+        if "args" in data and not isinstance(data["args"], dict):
+            raise ValueError("'args' must be an object")
+        return data
+
+    @activity.defn
+    async def get_wf_env_vars(self) -> Dict[str, str]:
+        """Return relevant environment variables for the workflow."""
+
+        keys = ["OPENAI_API_KEY", "ANTHROPIC_API_KEY"]
+        return {key: os.environ.get(key, "") for key in keys}

--- a/discovery-agent/tests/test_agent_activities.py
+++ b/discovery-agent/tests/test_agent_activities.py
@@ -1,0 +1,57 @@
+import sys
+import types
+import pytest
+from pathlib import Path
+
+# Stub temporalio to avoid dependency in tests
+activity_module = types.SimpleNamespace(defn=lambda f: f)
+temporal_stub = types.ModuleType("temporalio")
+temporal_stub.activity = activity_module
+sys.modules["temporalio"] = temporal_stub
+
+# Ensure the temporal modules are importable
+sys.path.append(str(Path(__file__).resolve().parents[1] / "temporal"))
+
+from agent_activities import AgentActivities
+
+
+@pytest.mark.asyncio
+async def test_agent_toolplanner_valid():
+    activities = AgentActivities()
+    prompt = '{"tool": "add", "args": {"a": 1, "b": 2}}'
+    result = await activities.agent_toolPlanner(prompt)
+    assert result == 3
+
+
+@pytest.mark.asyncio
+async def test_agent_toolplanner_unknown_tool():
+    activities = AgentActivities()
+    prompt = '{"tool": "missing", "args": {}}'
+    with pytest.raises(KeyError):
+        await activities.agent_toolPlanner(prompt)
+
+
+@pytest.mark.asyncio
+async def test_agent_validatePrompt_valid():
+    activities = AgentActivities()
+    prompt = '{"tool": "echo", "args": {"text": "hi"}}'
+    parsed = await activities.agent_validatePrompt(prompt)
+    assert parsed["tool"] == "echo"
+    assert parsed["args"]["text"] == "hi"
+
+
+@pytest.mark.asyncio
+async def test_agent_validatePrompt_invalid_json():
+    activities = AgentActivities()
+    bad_prompt = '{tool:"nope"}'
+    with pytest.raises(ValueError):
+        await activities.agent_validatePrompt(bad_prompt)
+
+
+@pytest.mark.asyncio
+async def test_get_wf_env_vars(monkeypatch):
+    activities = AgentActivities()
+    monkeypatch.setenv("OPENAI_API_KEY", "openai")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic")
+    result = await activities.get_wf_env_vars()
+    assert result == {"OPENAI_API_KEY": "openai", "ANTHROPIC_API_KEY": "anthropic"}

--- a/discovery-agent/tests/test_deep_agent.py
+++ b/discovery-agent/tests/test_deep_agent.py
@@ -69,7 +69,7 @@ temporal_stub.activity = types.SimpleNamespace(defn=lambda f: f)
 temporal_stub.workflow = types.SimpleNamespace(defn=lambda f: f, run=lambda f: f)
 sys.modules["temporalio"] = temporal_stub
 
-sys.path.append(str(Path(__file__).resolve().parent.parent))
+sys.path.append(str(Path(__file__).resolve().parent.parent / "temporal"))
 from deep_agent import create_deep_agent, run_agent
 import temporal_workflow
 

--- a/discovery-agent/tests/test_deep_agent_features.py
+++ b/discovery-agent/tests/test_deep_agent_features.py
@@ -63,7 +63,7 @@ openai_stub.get_default_model = _stub_get_default_model
 sys.modules["openai_model"] = openai_stub
 
 # Make deep_agent importable
-sys.path.append(str(Path(__file__).resolve().parents[1] / "discovery-agent/temporal"))
+sys.path.append(str(Path(__file__).resolve().parents[1] / "temporal"))
 import deep_agent
 from deep_agent import run_agent, SUBAGENTS
 

--- a/discovery-agent/tests/test_registries.py
+++ b/discovery-agent/tests/test_registries.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from dataclasses import asdict
 
 # Make registry modules importable
-sys.path.append(str(Path(__file__).resolve().parents[1] / "discovery-agent/temporal"))
+sys.path.append(str(Path(__file__).resolve().parents[1] / "temporal"))
 
 import registries
 import tool_registry


### PR DESCRIPTION
## Summary
- add AgentActivities class exposing `agent_toolPlanner`, `agent_validatePrompt`, and `get_wf_env_vars` Temporal activities
- include JSON sanitation, parsing, and tool dispatch helpers
- cover activities with tests for valid/invalid prompts and error paths
- move Temporal tests under `discovery-agent/tests`

## Testing
- `pytest discovery-agent/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68b06f83dcf4832aa98cabc30c64852c