### PR TITLE
Add prompt templates and helper utilities for Temporal agent

### DIFF
--- a/discovery-agent/temporal/prompts.py
+++ b/discovery-agent/temporal/prompts.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+"""Prompt templates and rendering helpers for Temporal agents.
+
+This module centralises the text templates used by the Temporal agent
+workflows.  Templates are simple ``str.format`` strings with placeholders for
+runtime values.  Helper functions safely render the templates while escaping
+any curly braces in the provided values so that user content does not
+interfere with ``str.format`` substitution.
+"""
+
+from typing import Iterable, Mapping, Sequence
+
+__all__ = [
+    "GENAI_PROMPT",
+    "TOOL_COMPLETION_PROMPT",
+    "render_genai_prompt",
+    "render_tool_completion_prompt",
+]
+
+# ---------------------------------------------------------------------------
+# Templates
+# ---------------------------------------------------------------------------
+
+GENAI_PROMPT = (
+    "You are an AI assistant.\n\n"
+    "Current goal:\n{goal}\n\n"
+    "Conversation so far:\n{history}\n\n"
+    "You can use the following tools:\n{tools}\n\n"
+    "Respond with the next action or final answer."
+)
+
+TOOL_COMPLETION_PROMPT = (
+    "The tool \"{tool}\" has completed with result:\n\n"
+    "{result}\n\n"
+    "Continue assisting the user toward the goal:\n{goal}"
+)
+
+
+# ---------------------------------------------------------------------------
+# Rendering helpers
+# ---------------------------------------------------------------------------
+
+def render_genai_prompt(
+    history: Sequence[Mapping[str, str]],
+    goal: str,
+    tools: Iterable[str],
+) -> str:
+    """Render ``GENAI_PROMPT`` with ``history``, ``goal`` and ``tools``.
+
+    Args:
+        history: Sequence of message mappings with ``role`` and ``content`` keys.
+        goal: The current objective for the agent.
+        tools: Iterable of tool names available to the agent.
+    """
+
+    history_lines = [f"{m['role']}: {m['content']}" for m in history]
+    history_text = "\n".join(history_lines) if history_lines else "<no conversation>"
+    tools_text = "\n".join(f"- {t}" for t in tools) if tools else "<no tools>"
+    return GENAI_PROMPT.format(history=history_text, goal=goal, tools=tools_text)
+
+
+def render_tool_completion_prompt(tool: str, result: str, goal: str) -> str:
+    """Render ``TOOL_COMPLETION_PROMPT`` for a completed tool call."""
+
+    return TOOL_COMPLETION_PROMPT.format(tool=tool, result=result, goal=goal)

--- a/discovery-agent/tests/test_prompts.py
+++ b/discovery-agent/tests/test_prompts.py
@@ -1,0 +1,51 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "temporal"))
+
+from prompts import (
+    GENAI_PROMPT,
+    TOOL_COMPLETION_PROMPT,
+    render_genai_prompt,
+    render_tool_completion_prompt,
+)
+
+
+def test_render_genai_prompt_substitution_and_escaping():
+    history = [
+        {"role": "user", "content": "Compute {1+1}"},
+        {"role": "assistant", "content": "Result was {2}"},
+    ]
+    goal = "Answer {math question}"
+    tools = ["calc", "search{engine}"]
+
+    prompt = render_genai_prompt(history, goal, tools)
+
+    # Check that placeholders were substituted
+    assert "Answer {math question}" in prompt
+    assert "user: Compute {1+1}" in prompt
+    assert "assistant: Result was {2}" in prompt
+    assert "- calc" in prompt and "- search{engine}" in prompt
+
+    # Ensure no raw template fields remain
+    assert "{goal}" not in prompt
+    assert "{history}" not in prompt
+    assert "{tools}" not in prompt
+
+    # Ensure braces were preserved, not treated as format tokens
+    assert "{{" not in prompt and "}}" not in prompt
+
+
+def test_render_tool_completion_prompt_substitution_and_escaping():
+    output = render_tool_completion_prompt(
+        tool="calc{tool}",
+        result="5 > 3 {True}",
+        goal="Explain {comparison}",
+    )
+
+    assert "calc{tool}" in output
+    assert "5 > 3 {True}" in output
+    assert "Explain {comparison}" in output
+    assert "{result}" not in output
+    assert "{goal}" not in output
+    assert "{{" not in output and "}}" not in output


### PR DESCRIPTION
## Summary
- introduce `GENAI_PROMPT` and `TOOL_COMPLETION_PROMPT` templates
- add rendering helpers that inject conversation history, goal, and tools
- test prompt rendering for proper substitution and brace handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b075d82748832a90e486120622c359