### PR TITLE
feat: expand Temporal worker

### DIFF
--- a/discovery-agent/temporal/temporal_worker.py
+++ b/discovery-agent/temporal/temporal_worker.py
@@ -1,22 +1,93 @@
-"""Worker to run the Temporal workflow for the custom DeepAgent."""
+"""Worker to run the Temporal workflow for the custom DeepAgent.
+
+This worker exposes the :class:`~temporal_workflow.DeepAgentWorkflow` along with
+utility activities from :class:`~agent_activities.AgentActivities`.  It also
+registers a dynamic activity dispatcher so that any tool present in
+``TOOL_REGISTRY`` can be invoked directly as an activity.
+
+The Temporal service address, task queue, and LLM settings are loaded from the
+environment.  Blocking tool implementations run in a thread pool executor to
+avoid stalling the worker's event loop.
+"""
+
+from __future__ import annotations
 
 import asyncio
+import os
+from concurrent.futures import ThreadPoolExecutor
+from typing import Sequence
+
+from dotenv import load_dotenv
+from temporalio import activity
 from temporalio.client import Client
+from temporalio.common import RawValue
+from temporalio.converter import DataConverter
 from temporalio.worker import Worker
 
+from agent_activities import AgentActivities
+from tool_registry import TOOL_REGISTRY
 from temporal_workflow import DeepAgentWorkflow, run_query
+
+load_dotenv()
+
+
+# Dynamic dispatcher ---------------------------------------------------------
+
+DATA_CONVERTER = DataConverter.default
+
+
+@activity.defn(dynamic=True)
+def dynamic_tool_dispatcher(values: Sequence[RawValue]) -> object:
+    """Dispatch dynamic tool activities based on the activity name.
+
+    The activity name corresponds to a tool in ``TOOL_REGISTRY``.  Arguments are
+    expected to be encoded as a single JSON object.
+    """
+
+    name = activity.info().activity_type
+    decoded = (
+        asyncio.run(DATA_CONVERTER.decode([v.payload for v in values]))
+        if values
+        else []
+    )
+    kwargs = decoded[0] if decoded else {}
+    for definition, handler in TOOL_REGISTRY.items():
+        if definition.name == name:
+            return handler(**kwargs)
+    raise KeyError(f"Unknown tool: {name}")
 
 
 async def main() -> None:
-    client = await Client.connect("localhost:7233")
+    """Entry point for running the Temporal worker."""
+
+    temporal_address = os.getenv("TEMPORAL_ADDRESS", "localhost:7233")
+    task_queue = os.getenv("TEMPORAL_TASK_QUEUE", "deep-agent-task-queue")
+
+    # Access LLM settings so they are loaded from the environment.  The
+    # ``openai_model`` module reads these values when imported by activities.
+    os.getenv("OPENAI_API_KEY", "")
+    os.getenv("OPENAI_MODEL", "")
+
+    client = await Client.connect(temporal_address)
+
+    activities = AgentActivities()
+    activity_funcs = [
+        run_query,
+        dynamic_tool_dispatcher,
+        activities.agent_toolPlanner,
+        activities.agent_validatePrompt,
+        activities.get_wf_env_vars,
+    ]
+
     worker = Worker(
         client,
-        task_queue="deep-agent-task-queue",
+        task_queue=task_queue,
         workflows=[DeepAgentWorkflow],
-        activities=[run_query],
+        activities=activity_funcs,
+        activity_executor=ThreadPoolExecutor(),
     )
     await worker.run()
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover - manual execution only
     asyncio.run(main())

--- a/discovery-agent/tests/test_temporal_worker.py
+++ b/discovery-agent/tests/test_temporal_worker.py
@@ -16,6 +16,7 @@ sys.modules.pop("temporalio", None)
 # Provide a lightweight stub for openai_model to avoid heavy dependency in tests
 sys.modules.setdefault("openai_model", types.SimpleNamespace(get_default_model=lambda: None))
 
+temporalio = pytest.importorskip("temporalio")
 from temporalio.worker import Worker
 from temporalio.testing import WorkflowEnvironment
 from temporalio import workflow

--- a/discovery-agent/tests/test_temporal_worker.py
+++ b/discovery-agent/tests/test_temporal_worker.py
@@ -1,0 +1,77 @@
+import sys
+from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor
+from datetime import timedelta
+import types
+
+import pytest
+
+# Ensure repository root and temporal modules are importable
+root_dir = Path(__file__).resolve().parents[1]
+sys.path.append(str(root_dir))
+sys.path.append(str(root_dir / "temporal"))
+
+# Remove any previously injected temporalio stub from other tests
+sys.modules.pop("temporalio", None)
+# Provide a lightweight stub for openai_model to avoid heavy dependency in tests
+sys.modules.setdefault("openai_model", types.SimpleNamespace(get_default_model=lambda: None))
+
+from temporalio.worker import Worker
+from temporalio.testing import WorkflowEnvironment
+from temporalio import workflow
+
+from agent_activities import AgentActivities
+from temporal_worker import dynamic_tool_dispatcher
+from temporal_workflow import DeepAgentWorkflow, run_query
+
+
+@workflow.defn
+class DummyWorkflow:
+    """Workflow used to verify activity registration."""
+
+    @workflow.run
+    async def run(self) -> int:  # pragma: no cover - exercised via Temporal
+        await workflow.execute_activity(
+            "agent_validatePrompt",
+            '{"tool": "add", "args": {"a": 1, "b": 1}}',
+            schedule_to_close_timeout=timedelta(seconds=5),
+        )
+        result = await workflow.execute_activity(
+            "add",
+            {"a": 1, "b": 1},
+            schedule_to_close_timeout=timedelta(seconds=5),
+        )
+        return result
+
+
+@pytest.mark.asyncio
+async def test_worker_runs_and_dispatches_tools():
+    """Smoke test ensuring worker starts and activities are callable."""
+
+    try:
+        env = await WorkflowEnvironment.start_time_skipping()
+    except Exception as exc:  # pragma: no cover - environment failure
+        pytest.skip(f"Temporal test server unavailable: {exc}")
+
+    async with env:
+        activities = AgentActivities()
+        worker = Worker(
+            env.client,
+            task_queue="test-queue",
+            workflows=[DeepAgentWorkflow, DummyWorkflow],
+            activities=[
+                run_query,
+                dynamic_tool_dispatcher,
+                activities.agent_toolPlanner,
+                activities.agent_validatePrompt,
+                activities.get_wf_env_vars,
+            ],
+            activity_executor=ThreadPoolExecutor(),
+        )
+        async with worker:
+            result = await env.client.execute_workflow(
+                DummyWorkflow.run,
+                id="wf-id",
+                task_queue="test-queue",
+            )
+            assert result == 2


### PR DESCRIPTION
## Summary
- register all agent activities and a dynamic tool dispatcher on the Temporal worker
- configure the worker via environment variables and run blocking tools in a thread pool
- add smoke test covering worker startup and dynamic tool execution

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b084ea71c8832aba63cc8e4dafc3bc