### PR TITLE
Add FastAPI chat provider, CLI chat, and workflow tests

### DIFF
--- a/discovery-agent/README.md
+++ b/discovery-agent/README.md
@@ -16,3 +16,15 @@ result = await agent("2 + 2?")
 The returned callable mirrors `run_agent` but applies the configuration above on
 every invocation, letting callers focus on the question and optional
 instructions.
+
+## Command line chat
+
+For environments without a browser the repository provides a small CLI that
+talks to the FastAPI service exposing the Temporal workflow:
+
+```bash
+python cli_chat.py --api http://localhost:8000
+```
+
+The script starts a new workflow and allows chatting from the terminal. Use
+`Ctrl+C` to end the session.

--- a/discovery-agent/cli_chat.py
+++ b/discovery-agent/cli_chat.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+"""Simple CLI to interact with the FastAPI DeepAgent endpoints.
+
+Usage:
+    python cli_chat.py --api http://localhost:8000
+
+The script starts a new workflow and lets the user chat with it from the
+terminal. Press Ctrl+C to exit.
+"""
+
+import argparse
+import os
+import time
+from typing import List
+
+import requests
+
+
+def start_workflow(api: str) -> str:
+    res = requests.post(f"{api}/workflow/start", json={})
+    res.raise_for_status()
+    return res.json()["workflow_id"]
+
+
+def fetch_history(api: str, wid: str) -> List[dict]:
+    res = requests.get(f"{api}/workflow/{wid}/history")
+    res.raise_for_status()
+    return res.json().get("history", [])
+
+
+def send_prompt(api: str, wid: str, prompt: str) -> None:
+    res = requests.post(f"{api}/workflow/{wid}/prompt", json={"prompt": prompt})
+    res.raise_for_status()
+
+
+def end_chat(api: str, wid: str) -> None:
+    try:
+        requests.post(f"{api}/workflow/{wid}/end", timeout=2)
+    except Exception:
+        pass
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="CLI chat with DeepAgent")
+    parser.add_argument("--api", default=os.environ.get("DISCOVERY_API_URL", "http://localhost:8000"),
+                        help="Base URL of FastAPI service")
+    args = parser.parse_args()
+    api = args.api.rstrip("/")
+
+    wid = start_workflow(api)
+    print(f"Workflow started: {wid}")
+    history_len = 0
+    try:
+        while True:
+            prompt = input("You: ")
+            if not prompt:
+                continue
+            send_prompt(api, wid, prompt)
+            # Poll for a new assistant message
+            while True:
+                time.sleep(1)
+                hist = fetch_history(api, wid)
+                if len(hist) > history_len + 1:
+                    # Expect a pair of messages: user and assistant
+                    msg = hist[-1].get("assistant")
+                    if msg:
+                        print(f"Agent: {msg}")
+                    history_len = len(hist)
+                    break
+    except KeyboardInterrupt:
+        pass
+    finally:
+        end_chat(api, wid)
+        print("\nChat ended.")
+
+
+if __name__ == "__main__":
+    main()

--- a/discovery-agent/tests/test_temporal_workflow.py
+++ b/discovery-agent/tests/test_temporal_workflow.py
@@ -107,7 +107,35 @@ async def test_continue_as_new(monkeypatch):
         await task
 
     kwargs = exc.value.kwargs_data
-    assert kwargs["conversation_history"][0]["user"] == "q1"
+    assert kwargs["conversation_history"] == [{"user": "q1"}, {"assistant": "resp:q1"}]
     assert kwargs["remaining_turns"] == 4
     assert kwargs["prompt_queue"] == ["q2"]
+
+
+@pytest.mark.asyncio
+async def test_activity_retry(monkeypatch):
+    attempts = {"n": 0}
+
+    async def flaky_run_query(question, instructions="", tools=None, mcp_endpoints=None):
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            raise RuntimeError("fail")
+        return f"resp:{question}", None
+
+    async def execute_with_retry(fn, *args, **kwargs):
+        while True:
+            try:
+                return await fn(*args)
+            except Exception:
+                if kwargs.get("_retry", 0) >= 1:
+                    raise
+                kwargs["_retry"] = kwargs.get("_retry", 0) + 1
+
+    monkeypatch.setattr(workflow_stub, "execute_activity", execute_with_retry)
+    monkeypatch.setattr(tw, "run_query", flaky_run_query)
+
+    wf = tw.DeepAgentWorkflow()
+    history = await wf.run("hi", remaining_turns=1, continue_after=10)
+    assert [m for d in history for m in d.values()] == ["hi", "resp:hi"]
+    assert attempts["n"] == 2
 

--- a/discovery-ui/src/app/page.tsx
+++ b/discovery-ui/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React from "react";
-import { HttpProvider } from "@/lib/provider";
+import { FastApiProvider } from "@/lib/provider";
 import DiscoveryChat, { Chat } from "@/components/DiscoveryChat";
 import { Button } from "@/components/ui/button";
 import { Mic, AudioLines, Plus } from "lucide-react";
@@ -11,7 +11,7 @@ export default function HomePage() {
 
   React.useEffect(() => {
     const ac = new AbortController();
-    HttpProvider.listChats(ac.signal).then(setChats).catch(() => setChats([]));
+    FastApiProvider.listChats(ac.signal).then(setChats).catch(() => setChats([]));
     return () => ac.abort();
   }, []);
 
@@ -55,7 +55,7 @@ export default function HomePage() {
           </div>
         </div>
       ) : (
-        <DiscoveryChat provider={HttpProvider} />
+        <DiscoveryChat provider={FastApiProvider} />
       )}
     </main>
   );

--- a/discovery-ui/src/lib/provider.ts
+++ b/discovery-ui/src/lib/provider.ts
@@ -144,6 +144,78 @@ export const HttpProvider: DiscoveryAgentDataProvider = {
   }
 };
 
+// ---------------------------------------------------------------------------
+// FastAPI-backed provider
+// ---------------------------------------------------------------------------
+
+const FASTAPI_BASE = process.env.NEXT_PUBLIC_AGENT_API || "http://localhost:8000";
+
+const fastApiChats: Chat[] = [];
+
+export const FastApiProvider: DiscoveryAgentDataProvider = {
+  async listChats(_signal?: AbortSignal) {
+    return fastApiChats;
+  },
+  async createChat(params, _signal?: AbortSignal) {
+    try {
+      const res = await fetch(`${FASTAPI_BASE}/workflow/start`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ question: params?.title ?? undefined }),
+      });
+      if (!res.ok) return null;
+      const data: any = await res.json().catch(() => ({} as any));
+      const id = typeof data?.workflow_id === "string" ? data.workflow_id : undefined;
+      if (!id) return null;
+      const chat: Chat = { id, title: params?.title || `Chat ${id}` };
+      fastApiChats.push(chat);
+      return chat;
+    } catch {
+      return null;
+    }
+  },
+  async listMessages(chatId, _signal?: AbortSignal) {
+    try {
+      const res = await fetch(`${FASTAPI_BASE}/workflow/${encodeURIComponent(chatId)}/history`);
+      if (!res.ok) return [];
+      const data: any = await res.json().catch(() => ({} as any));
+      const history = Array.isArray(data?.history) ? (data.history as any[]) : [];
+      const messages: Message[] = [];
+      history.forEach((h: any, i: number) => {
+        const [[role, text]] = Object.entries(h);
+        if (typeof text === "string") {
+          messages.push({ id: `${i}`, role: role === "user" ? "user" : "agent", text, createdAt: new Date().toISOString() });
+        }
+      });
+      return messages;
+    } catch {
+      return [];
+    }
+  },
+  async sendMessage(body, _signal?: AbortSignal) {
+    try {
+      await fetch(`${FASTAPI_BASE}/workflow/${encodeURIComponent(body.chatId)}/prompt`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ prompt: body.text }),
+      });
+    } catch {
+      return;
+    }
+  },
+  async deleteChat(chatId, _signal?: AbortSignal) {
+    try {
+      await fetch(`${FASTAPI_BASE}/workflow/${encodeURIComponent(chatId)}/end`, { method: "POST" });
+    } catch {
+    }
+    const idx = fastApiChats.findIndex((c) => c.id === chatId);
+    if (idx >= 0) fastApiChats.splice(idx, 1);
+  },
+  async listArtifacts(_params, _signal?: AbortSignal) {
+    return [];
+  },
+};
+
 type Dict = Record<string, unknown>;
 
 function isRecord(x: unknown): x is Dict {


### PR DESCRIPTION
## Summary
- Wire Next.js chat to FastAPI workflow endpoints via new provider
- Introduce a terminal-based chat client for environments without a browser
- Add workflow tests for signal/query flow, continue-as-new, and activity retries

## Testing
- `pytest tests -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b09de5cdb4832a8ddf0555780c4769